### PR TITLE
Replace native hexdec for BCMath::HexDec

### DIFF
--- a/src/API/Eth.php
+++ b/src/API/Eth.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace EthereumRPC\API;
 
+use EthereumRPC\BcMath;
 use EthereumRPC\EthereumRPC;
 use EthereumRPC\Exception\GethException;
 use EthereumRPC\Response\Block;
@@ -160,7 +161,7 @@ class Eth
             throw GethException::unexpectedResultType("eth_getBalance", "hexdec", gettype($balance));
         }
 
-        $balance = strval(hexdec($balance));
+        $balance = strval(BcMath::HexDec($balance));
         return bcdiv($balance, bcpow("10", "18", 0), EthereumRPC::SCALE);
     }
 }


### PR DESCRIPTION
Hey @furqansiddiqui, I was using two different packages to handle ethereum RPC calls. Now I'm refactoring my code to use only yours.

So I start with the basic ones. First one was the get accounts, that one worked perfectly.

Next one is getBalance from an address, It works but the call always returns zero. I checked the response from the network `0x56bc75e2d63100000`, which is right. I already converted this value using online converters and a PHP package called [mbezhanov/ethereum-converter](https://github.com/mbezhanov/ethereum-converter). Both give me `100 ETH`.

So I suspect that native `php + ext-bcmath` function called `hexdec` is not handling very large numbers or precision. I changed for your implementation of BcMath and works perfectly.

There is another PR.

Kind regards.