### PR TITLE
Added eth_sendTransaction

### DIFF
--- a/src/API/Eth.php
+++ b/src/API/Eth.php
@@ -19,6 +19,7 @@ use EthereumRPC\Exception\GethException;
 use EthereumRPC\Response\Block;
 use EthereumRPC\Response\Transaction;
 use EthereumRPC\Response\TransactionReceipt;
+use EthereumRPC\BcMath;
 
 /**
  * Class Eth
@@ -162,5 +163,33 @@ class Eth
 
         $balance = strval(hexdec($balance));
         return bcdiv($balance, bcpow("10", "18", 0), EthereumRPC::SCALE);
+    }
+
+    /**
+     * @param string $from
+     * @param string $to
+     * @param string $ethAmount
+     * @return string
+     * @throws GethException
+     * @throws \EthereumRPC\Exception\ConnectionException
+     * @throws \HttpClient\Exception\HttpClientException
+     */
+    public function sendTransaction(string $from, string $to, string $ethAmount): string
+    {
+        $value = "0x" . BcMath::DecHex(bcmul($ethAmount, bcpow("10", "18"), 0));
+
+        $transaction = [
+            "from" => $from,
+            "to" => $to,
+            "value" => $value
+        ];
+
+        $request = $this->client->jsonRPC("eth_sendTransaction", null, [$transaction]);
+        $send = $request->get("result");
+        if (!is_string($send)) {
+            throw GethException::unexpectedResultType("eth_sendTransaction", "string", gettype($send));
+        }
+
+        return $send;
     }
 }


### PR DESCRIPTION
Hey @furqansiddiqui, as I mentioned on #7. I'm moving all my code to use just your package.

On the PR #7, I "fixed" the getBalance from an address.

Moving to the next one, that will it be the `eth_sendTransaction` I saw that you implemented the `personal_sendTransaction` which need the password to send the transaction, probably to sign the transaction. But on my previous code, I'm using the `eth_sendTransaction`. which is similar to the [web3.js implementation ](https://web3js.readthedocs.io/en/1.0/web3-eth.html#sendtransaction)

So I created that method to keep all my code working without any break changes.

There is another PR.

Kind regards.